### PR TITLE
Fix GHC 7.4 build

### DIFF
--- a/apache-md5.cabal
+++ b/apache-md5.cabal
@@ -44,6 +44,10 @@ library
       base >= 4 && < 5
     , bytestring >= 0.10 && < 0.11
 
+  if impl(ghc < 7.6)
+    build-depends: ghc-prim
+
+
   if flag(deepseq)
     cpp-options:        -DWITH_deepseq
     build-depends:      deepseq >= 1.1.0.0 && < 2


### PR DESCRIPTION
GHC 7.4's Data.Generics lives in ghc-prim

Earlier GHCs are not affected because of CPP.

I've revised existing versions: https://hackage.haskell.org/package/apache-md5-0.6.1.2/revisions/
